### PR TITLE
Manually update artifact-related actions

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build HTML output
         run: make build
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_output
           path: .build/
@@ -76,7 +76,7 @@ jobs:
         with:
           node-version: 18.x
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_output
           path: build/


### PR DESCRIPTION
Dependabot's PRs are failing, first guess is, that these have to be updated at the same time.